### PR TITLE
Listen on one or more addresses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 3
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "bytes"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13,6 +25,42 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clap"
+version = "3.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c167e37342afc5f33fd87bbc870cedd020d2a6dffa05d45ccd9241fbdd146db"
+dependencies = [
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "lazy_static",
+ "textwrap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "189ddd3b5d32a70b35e7686054371742a937b0d99128e76dde6340210e966669"
+dependencies = [
+ "os_str_bytes",
+]
 
 [[package]]
 name = "fnv"
@@ -51,12 +99,27 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
 name = "hokay"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
+ "clap",
+ "futures-util",
  "hyper",
  "tokio",
 ]
@@ -116,6 +179,16 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
+dependencies = [
+ "autocfg",
+ "hashbrown",
 ]
 
 [[package]]
@@ -184,6 +257,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -194,6 +273,30 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -223,6 +326,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
+
+[[package]]
 name = "socket2"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,6 +351,12 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "tokio"
@@ -307,6 +422,12 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hokay"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 description = "A bare-bones HTTP server that always returns with 204 No Content."
@@ -8,8 +8,20 @@ readme = "README.md"
 repository = "https://github.com/olix0r/hokay"
 
 [dependencies]
+clap = { version = "3", default-features = false, features = ["cargo", "derive", "std"] }
+futures-util = { version = "0.3", default-features = false, features = ["std"] }
 hyper = { version = "0.14", default-features = false, features = ["http1", "runtime", "server"] }
-tokio = { version = "1", features = ["macros", "net", "rt", "signal", "sync"] }
+
+[dependencies.tokio]
+version = "1"
+default-features = false
+features = [
+    "macros",
+    "net",
+    "rt",
+    "signal",
+    "sync",
+]
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ infrequently.
 ## Usage
 
 ```text
-:; hokay 8080
+:; hokay
 ```
 
 ```text

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,81 +1,81 @@
+#![deny(warnings, rust_2018_idioms)]
+
+use clap::Parser;
+
+#[derive(Debug, Parser)]
+#[clap(about, version)]
+struct Args {
+    /// One or more addresses to listen on.
+    #[clap(default_value = "0.0.0.0:8080")]
+    addrs: Vec<std::net::SocketAddr>,
+}
+
 /// Runs a basic HTTP server that always returns 204 No Content.
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let port = get_port_from_args()?;
+    const VERSION: &str = env!("CARGO_PKG_VERSION");
+    let Args { addrs } = Args::parse();
 
-    let (tx, rx) = tokio::sync::oneshot::channel();
-    let mut task = tokio::spawn({
-        let addr = std::net::SocketAddr::new([0, 0, 0, 0].into(), port);
-        let server = hyper::server::Server::try_bind(&addr)?
-            // Allow weird clients (like netcat).
-            .http1_half_close(true)
-            // Prevent port scanners, etc, from holding connections open.
-            .http1_header_read_timeout(std::time::Duration::from_secs(2))
-            // Use a small buffer, since we don't really transfer much data.
-            .http1_max_buf_size(8 * 1024);
+    let (tx, rx) = tokio::sync::watch::channel(());
+    let tasks = addrs
+        .into_iter()
+        .map(|addr| {
+            let server = hyper::server::Server::try_bind(&addr)?
+                // Allow weird clients (like netcat).
+                .http1_half_close(true)
+                // Prevent port scanners, etc, from holding connections open.
+                .http1_header_read_timeout(std::time::Duration::from_secs(2))
+                // Use a small buffer, since we don't really transfer much data.
+                .http1_max_buf_size(8 * 1024);
+            println!("Listening on {addr}");
 
-        const VERSION: &str = env!("CARGO_PKG_VERSION");
-        server
-            .serve(hyper::service::make_service_fn(|_conn| async move {
-                Ok::<_, hyper::Error>(hyper::service::service_fn(|_req| async move {
-                    Ok::<_, hyper::Error>(
-                        hyper::Response::builder()
-                            .header(hyper::header::SERVER, format!("hokay/{VERSION}"))
-                            .status(hyper::StatusCode::NO_CONTENT)
-                            .body(hyper::Body::default())
-                            .unwrap(),
-                    )
-                }))
-            }))
-            .with_graceful_shutdown(async move {
-                let _ = rx.await;
-            })
-    });
+            let mut rx = rx.clone();
+            Ok::<_, hyper::Error>(tokio::spawn(
+                server
+                    .serve(hyper::service::make_service_fn(|_conn| async move {
+                        Ok::<_, hyper::Error>(hyper::service::service_fn(|_req| async move {
+                            Ok::<_, hyper::Error>(
+                                hyper::Response::builder()
+                                    .header(hyper::header::SERVER, format!("hokay/{VERSION}"))
+                                    .status(hyper::StatusCode::NO_CONTENT)
+                                    .body(hyper::Body::default())
+                                    .unwrap(),
+                            )
+                        }))
+                    }))
+                    .with_graceful_shutdown(async move {
+                        let _ = rx.changed().await;
+                        println!("Closing {addr}");
+                    }),
+            ))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let mut servers = futures_util::future::try_join_all(tasks);
 
+    // When SIGINT or SIGTERM is received, notify servers to
     let mut interrupt = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())?;
     let mut terminate = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())?;
     tokio::select! {
-        res = (&mut task) => match res {
-            Ok(Ok(())) => return Err(format!("server exited unexpectedly").into()),
-            Ok(Err(error)) => return Err(format!("server exited unexpectedly: {error}").into()),
+        res = (&mut servers) => match res {
+            Ok(ress) => match ress.into_iter().collect::<Result<Vec<_>, _>>() {
+                Ok(_) => return Err("server exited unexpectedly".into()),
+                Err(error) => return Err(format!("server exited unexpectedly: {error}").into()),
+            },
             Err(error) => return Err(format!("server exited unexpectedly: {error}").into()),
         },
         _ = interrupt.recv() => {
             let _ = tx.send(());
-            if let Err(error) = task.await {
+            if let Err(error) = servers.await {
                 return Err(format!("server exited unexpectedly: {error}").into());
             }
         },
         _ = terminate.recv() => {
             let _ = tx.send(());
-            if let Err(error) = task.await {
+            if let Err(error) = servers.await {
                 return Err(format!("server exited unexpectedly: {error}").into());
             }
         },
     }
 
     Ok(())
-}
-
-fn get_port_from_args() -> Result<u16, Box<dyn std::error::Error>> {
-    let mut args = std::env::args();
-
-    match args.next() {
-        Some(name) => {
-            if let Some(p) = args.next() {
-                if args.next().is_some() {
-                    return Err(format!("Too many arguments\nUsage: {} [<port>]", name).into());
-                }
-                match p.parse::<u16>() {
-                    Ok(port) => return Ok(port),
-                    Err(error) => return Err(format!("Invalid port: {error}").into()),
-                }
-            }
-        }
-        None => {
-            eprintln!("Process executed with no arguments");
-        }
-    }
-
-    Ok(8080)
 }


### PR DESCRIPTION
In order to listen on, for instance, both `::0` and `0.0.0.0`, hokay
needs to be able to listen on more than one address. This change updates
hokay to use `clap` to process command-line arguments and to provide
reasonable help messages.

This change also bumps the version to 0.2.0, as the command-line
interface has changed.