### PR TITLE
add `--status` argument for overriding the status code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "hokay"
 version = "0.2.2"
 edition = "2021"
 license = "MIT"
-description = "A bare-bones HTTP server that always returns with 204 No Content."
+description = "A bare-bones HTTP server that always returns an empty response."
 readme = "README.md"
 repository = "https://github.com/olix0r/hokay"
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # hokay
 
-A bare-bones HTTP/1 server that always returns `204 No content`.
+A bare-bones HTTP/1 server that always returns an empty response.
 
 This program aims to take minimal dependencies and is expected to be updated
 infrequently.
 
 ## Usage
+
+By default, `hokay` responds with `204 No Content`:
 
 ```text
 :; hokay
@@ -26,6 +28,30 @@ infrequently.
 < HTTP/1.1 204 No Content
 < server: hokay
 < date: Fri, 22 Apr 2022 15:18:10 GMT
+<
+* Connection #0 to host localhost left intact
+```
+
+Optionally, pass `--status` to override the response's status code:
+
+```text
+hokay --status 418
+```
+
+```text
+:; curl -v localhost:8080
+*   Trying 127.0.0.1:8080...
+* Connected to localhost (127.0.0.1) port 8080 (#0)
+> GET / HTTP/1.1
+> Host: localhost:8080
+> User-Agent: curl/7.87.0
+> Accept: */*
+>
+* Mark bundle as not supporting multiuse
+< HTTP/1.1 418 I'm a teapot
+< server: hokay/0.2.2
+< content-length: 0
+< date: Mon, 03 Apr 2023 19:55:49 GMT
 <
 * Connection #0 to host localhost left intact
 ```


### PR DESCRIPTION
Currently, `hokay` always responds with the status code 204 No Content. In some cases, such as testing how a client handles request errors, it may be desirable to run a very minimal server that returns a different status code.

This branch adds a new `--status <CODE>` command-line argument to `hokay` for overriding the returned status code. This argument is optional, and when it's not provided, `hokay` returns 204 No Content by default.

I've also updated the documentation to no longer state that `hokay` "always returns 204 No Content". :)